### PR TITLE
Fix Theme Site Demo

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,6 +2,7 @@ baseurl = "https://example.com"
 title = "Hugo Bare Min Theme"
 author = "Kaushal Modi"
 theme = "hugo-bare-min-theme"
+themesDir = "../.."
 
 enableEmoji = true
 enableGitInfo = true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -57,7 +57,7 @@
              font-size: 0.8em;
          }
          {{ if (not ($.Param "disable_debug")) }}
-             {{ partial "debugprint.css" | safeCSS }}
+             {{ partial "debugprint.css" . | safeCSS }}
          {{ end }}
          /* Captions */
          figcaption,

--- a/layouts/partials/debugprint.css
+++ b/layouts/partials/debugprint.css
@@ -1,0 +1,1 @@
+../../exampleSite/themes/hugo-debugprint/layouts/partials/debugprint.css

--- a/layouts/partials/debugprint.html
+++ b/layouts/partials/debugprint.html
@@ -1,0 +1,1 @@
+../../exampleSite/themes/hugo-debugprint/layouts/partials/debugprint.html

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "exampleSite/public"
-  command = "cd exampleSite && hugo"
+  command = "cd exampleSite && hugo --themesDir "themes"
 
 [context.production]
   [context.production.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "exampleSite/public"
-  command = "cd exampleSite && hugo --themesDir "themes"
+  command = "cd exampleSite && hugo --themesDir 'themes'"
 
 [context.production]
   [context.production.environment]


### PR DESCRIPTION
@kaushalmodi 

If you merge this PR then your theme's demo will generate once again on the Hugo Themes website despite the Theme Components that you have incorporated.

Basically the Themes Site Build Script can see your theme's components by creating relative symlinks under the theme's `/layouts/partials/` directory to the relevant partials under the theme components directories.

Once you merge this PR please let me know so that we can remove your theme from the `noDemo` list and close https://github.com/gohugoio/hugoThemes/issues/463

---

The above looks like a valid workaround for themes that use theme components on the Themes Site and it should be documented in the README of the themes repo.

cc: @bep @digitalcraftsman