### PR TITLE
Update MathJax to v3

### DIFF
--- a/layouts/partials/mathjax.html
+++ b/layouts/partials/mathjax.html
@@ -6,6 +6,6 @@
      that 'unsafe-inline can also be removed from script-src CSP.
 -->
 <script src="{{ "js/mathjax-config.js" | absURL }}"></script>
- <!-- https://gohugo.io/content-management/formats/#mathjax-with-hugo -->
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML"></script>
-<!-- <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML"></script> -->
+
+<!-- Use MathJax 3 for faster loading -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>

--- a/static/js/mathjax-config.js
+++ b/static/js/mathjax-config.js
@@ -1,28 +1,5 @@
 window.MathJax = {
-  chtml: {
-    displayAlign: "center",
-    displayIndent: "0em",
-    scale: 1
-  },
-  svg: {
-    scale: 1
-  },
   tex: {
-    tags: "ams",
-    multlineWidth: "85%",
-    tagSide: "right",
-    tagIndent: ".8em",
-    autoload: {
-      color: [],
-      colorV2: ['color']
-    },
-    packages: {'[+]': ['noerrors']}
-  },
-  options: {
-    ignoreHtmlClass: 'tex2jax_ignore',
-    processHtmlClass: 'tex2jax_process'
-  },
-  loader: {
-    load: ['[tex]/noerrors']
+    tags: "ams"
   }
 };

--- a/static/js/mathjax-config.js
+++ b/static/js/mathjax-config.js
@@ -1,17 +1,28 @@
 window.MathJax = {
+  chtml: {
     displayAlign: "center",
     displayIndent: "0em",
-    "HTML-CSS": { scale: 100,
-                  linebreaks: { automatic: "false" },
-                  webFont: "TeX"
-                },
-    SVG: {scale: 100,
-          linebreaks: { automatic: "false" },
-          font: "TeX"},
-    NativeMML: {scale: 100},
-    TeX: { equationNumbers: {autoNumber: "AMS"},
-           MultLineWidth: "85%",
-           TagSide: "right",
-           TagIndent: ".8em"
-         }
+    scale: 1
+  },
+  svg: {
+    scale: 1
+  },
+  tex: {
+    tags: "ams",
+    multlineWidth: "85%",
+    tagSide: "right",
+    tagIndent: ".8em",
+    autoload: {
+      color: [],
+      colorV2: ['color']
+    },
+    packages: {'[+]': ['noerrors']}
+  },
+  options: {
+    ignoreHtmlClass: 'tex2jax_ignore',
+    processHtmlClass: 'tex2jax_process'
+  },
+  loader: {
+    load: ['[tex]/noerrors']
+  }
 };


### PR DESCRIPTION
I used [this tool](https://mathjax.github.io/MathJax-demos-web/convert-configuration/convert-configuration.html) to convert the config. Assuming this doesn't break any tests, this can close kaushalmodi/ox-hugo#297.